### PR TITLE
Fix README.MD shell markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,33 @@
 #webpack-karma-typescript-starter
 ##Starter project for a webpack bundlin', typescript typin', karma test runnin' good time.
 
+
+### Clone the project
 ```sh
-# Clone the project
 git clone https://github.com/alexmunda/webpack-typescript-karma-starter.git
-
-# If you don't have typings installed.
+```
+### If you don't have typings installed.
+```sh
 npm install typings --global
+```
 
-# Install typings
+### Install typings
+```sh
 typings install
+```
 
-# Install packages
+### Install packages
+```sh
 npm install
+```
 
-# Run the tests
+### Run the tests
+```sh
 npm run test
+```
 
-# Create the webpack bundle
+### Create the webpack bundle
+```sh
 npm run start
 ```
+


### PR DESCRIPTION
Titles were included in the shell markdown. Now they are separate.
